### PR TITLE
add serviceName for grpc mode

### DIFF
--- a/app/src/main/java/com/github/shadowsocks/plugin/xray/ConfigFragment.kt
+++ b/app/src/main/java/com/github/shadowsocks/plugin/xray/ConfigFragment.kt
@@ -42,6 +42,7 @@ class ConfigFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChange
     private val mode by lazy { findPreference<ListPreference>("mode")!! }
     private val host by lazy { findPreference<EditTextPreference>("host")!! }
     private val path by lazy { findPreference<EditTextPreference>("path")!! }
+    private val serviceName by lazy { findPreference<EditTextPreference>("serviceName")!! }
     private val mux by lazy { findPreference<EditTextPreference>("mux")!! }
     private val certRaw by lazy { findPreference<EditTextPreference>("certRaw")!! }
     private val loglevel by lazy { findPreference<ListPreference>("loglevel")!! }
@@ -65,6 +66,7 @@ class ConfigFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChange
         putWithDefault("host", host.text, "cloudflare.com")
         putWithDefault("path", path.text, "/")
         putWithDefault("mux", mux.text, "1")
+        putWithDefault("serviceName", serviceName.text, "")
         putWithDefault("certRaw", certRaw.text?.replace("\n", ""), "")
         putWithDefault("loglevel", loglevel.value, "warning")
     }
@@ -81,6 +83,7 @@ class ConfigFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChange
         path.text = options["path"] ?: "/"
         mux.text = options["mux"] ?: "1"
         certRaw.text = options["certRaw"]
+        serviceName.text = options["serviceName"]
         loglevel.value = options["loglevel"] ?: "warning"
     }
 
@@ -106,6 +109,7 @@ class ConfigFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChange
         val (mode, tls) = readMode(newValue as String)
         path.isEnabled = mode == null
         mux.isEnabled = mode == null
+        serviceName.isEnabled = mode == "grpc"
         certRaw.isEnabled = mode != null || tls
         return true
     }

--- a/app/src/main/res/xml/config.xml
+++ b/app/src/main/res/xml/config.xml
@@ -18,6 +18,11 @@
         app:title="Path"
         app:useSimpleSummaryProvider="true"/>
     <EditTextPreference
+        app:key="serviceName"
+        app:persistent="false"
+        app:title="Service name"
+        app:useSimpleSummaryProvider="true"/>
+    <EditTextPreference
         app:key="mux"
         app:persistent="false"
         app:title="Concurrent connections"


### PR DESCRIPTION
Hi @teddysun,

I've added `Service name` selection to the plugin. It active only with `grpc` or `grpc-tls` transport.

I already use this feature on my android.

![image](https://user-images.githubusercontent.com/17034108/137597137-da33ad69-1c94-419d-809d-9904169c9fe5.png)

Thanks